### PR TITLE
Update Toy Musical link and remove Toy Musical 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ Lists most other BMS players, sorted by year of release. (Japanese)
 * [GroundbreakinG BMS Package](https://gdbg.tv/package/2022/)
 * [GENOSIDE BMS StarterPackage 2018](http://nekokan.dyndns.info/~lobsak/genocide/grade.html)
 * [GENOSIDE BMS StarterPackage](http://nekokan.dyndns.info/~lobsak/genoside/)
-* [Toy Musical Gateway](http://toymusical.net/)
-* [Toy Musical 3](http://nekokan.dyndns.info/~tm3/download.html)
 * [LUMINOUS](http://l-bms.space/1st/)
 * [Pure White](http://l-bms.space/2nd/)
 * [BMS Starter Pack 2006-2009](http://www.yamajet.com/bmssp/guide.html)
@@ -97,7 +95,8 @@ Lists most other BMS players, sorted by year of release. (Japanese)
 * [Korea BMS Starter Pack Polaris](https://k-bms.com/starter/polaris.jsp)
 * [Korea BMS Starter Pack Primrose](https://k-bms.com/primrose/)
 * [Lunatic Rave Endless Music](http://www.is-m.jp/lrem/download.html)
-
+* [Toy Musical 1 & 2 (PMS Starter Packs)](https://tm2.toymusical.net/download.html)
+  
 
 
 ## Player Utilities


### PR DESCRIPTION
I updated the Toy Musical link so that you can now download the Toy Musical 1 and 2 PMS packs.

I have to remove Toy Musical 3, as the files are actually not PMS, they are in a propietary file format called .n2s in which they need .n2x to work. They were only made to be played on its bundled player which means the music cannot be played on neither raja or LR2.